### PR TITLE
Initial landing page Teams foundation

### DIFF
--- a/foundations/README.md
+++ b/foundations/README.md
@@ -16,7 +16,7 @@ Review the articles below to learn more about the North Star architecture method
 
 * [Microsoft Power Platform](./powerPlatform)
 * [Microsoft Azure](./azure)
-* [Microsoft 365](./m365)
+* [Microsoft Teams](./teams)
 
 ---
 

--- a/foundations/m365/README.md
+++ b/foundations/m365/README.md
@@ -1,1 +1,0 @@
-# Microsoft 365 for Industries

--- a/foundations/teams/README.md
+++ b/foundations/teams/README.md
@@ -7,7 +7,7 @@ Recommendations and guidance on Microsoft Teams deployment in the enterprise is 
 
 | Reference implementation | Description | Deploy |
 |:----------------------|:------------|--------|
-| Microsoft Teams  for Industries | Coming soon| Coming soon
+| Microsoft Teams for Industries | Coming soon| Coming soon
 
 ## Design areas
 

--- a/foundations/teams/README.md
+++ b/foundations/teams/README.md
@@ -1,0 +1,28 @@
+# Microsoft Teams for Industries
+
+
+Microsoft Teams is an integral component for many industry-specific scenarios in Healthcare, Retail, Government, etc.
+
+Recommendations and guidance on Microsoft Teams deployment in the enterprise is documented in the [Teams documentation](https://docs.microsoft.com/en-us/microsoftteams/deploy-enterprise-overview)
+
+| Reference implementation | Description | Deploy |
+|:----------------------|:------------|--------|
+| Microsoft Teams  for Industries | Coming soon| Coming soon
+
+## Design areas
+
+Use the guidelines in the following Teams design areas article series to help you translate your requirements to Teams constructs and capabilities.
+
+* [Security, Privacy and Compliance](https://docs.microsoft.com/en-us/microsoftteams/security-compliance-overview)
+
+* [Management and monitoring](https://docs.microsoft.com/en-us/microsoftteams/manage-teams-overview)
+
+* [Chat, teams and channels](https://docs.microsoft.com/en-us/microsoftteams/deploy-chat-teams-channels-microsoft-teams-landing-page)
+
+* [Meetings and conferencing](https://docs.microsoft.com/en-us/microsoftteams/deploy-meetings-microsoft-teams-landing-page)
+
+* [Voice - Phone and PSTN Connectivity](https://docs.microsoft.com/en-us/microsoftteams/cloud-voice-landing-page)
+
+* [Devices and rooms management](https://docs.microsoft.com/en-us/microsoftteams/rooms/)
+
+* [Apps, bots and connectors](https://docs.microsoft.com/en-us/microsoftteams/deploy-apps-microsoft-teams-landing-page)


### PR DESCRIPTION
Added initial landing page for Teams foundation mainly consisting of links to existing docs from teams architecture/deployment center. 