### PR TITLE
Added Old Issue Templates Back

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,22 @@
+---
+name: "Bug report \U0001F41B"
+about: Report errors or unexpected behaviour
+title: 'Bug Report'
+labels: bug
+assignees: ''
+
+---
+
+<!-- Please read our Rules of Conduct: https://opensource.microsoft.com/codeofconduct/ -->
+<!-- Please search existing issues to avoid creating duplicates. -->
+
+**Describe the bug**
+
+
+**Steps to reproduce**
+
+1.
+2.
+
+**Screenshots**
+

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,14 @@
+---
+name: "Feature request \U0001F680"
+about: Suggest an idea for this project
+title: 'Feature Request'
+labels: feature
+assignees: ''
+
+---
+
+<!-- Please read our Rules of Conduct: https://opensource.microsoft.com/codeofconduct/ -->
+<!-- Please search existing issues to avoid creating duplicates. -->
+
+**Describe the solution you'd like**
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,6 @@
 <!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
 ## Summary of the Pull Request
 
-<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? -->
-## References
-
 <!-- Please review the items on the PR checklist before submitting-->
 ## PR Checklist
 * [ ] Closes Issue #xxx


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Added Old Issue Templates Back because the forms feature is only available for public repos today. We can switch to these once the feature becomes available for private repos or once the repo is made publicly available.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? -->
## References
No references

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Code of Conduct signed. If not, go to [Code of Conduct](https://github.com/microsoft/industry/blob/main/CODE_OF_CONDUCT.md).

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
No additional validation steps required.